### PR TITLE
Updated Plurimath submodule and Mml version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,5 @@ gem 'simplecov'
 gem 'ox'
 gem 'unitsml'
 gem 'monitor'
-gem 'mml', "~> 1"
+# gem 'mml'
+gem 'mml', github: "plurimath/mml", branch: "update/zeitwerk_removal_for_plurimath-js"

--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,4 @@ gem 'simplecov'
 gem 'ox'
 gem 'unitsml'
 gem 'monitor'
-# gem 'mml'
-gem 'mml', github: "plurimath/mml", branch: "update/zeitwerk_removal_for_plurimath-js"
+gem 'mml'

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,6 @@ bundle exec opal --esm -sjruby \
                  -gunitsml \
                  -ghtmlentities \
                  -gparslet \
-                 -gzeitwerk \
                  -gmonitor \
                  -sox \
                  -sox/ox \


### PR DESCRIPTION
This PR updates the submodule of **Plurimath**, locked **Mml** version, and removes the `zeitwerk` gem from the build file.

related => plurimath/plurimath#289