### PR TITLE
Mathml `intent` argument support

### DIFF
--- a/spec/to-mathml-intent.spec.js
+++ b/spec/to-mathml-intent.spec.js
@@ -1,0 +1,9 @@
+import Plurimath from "../dist"
+
+describe('to mathml with intent', () => {
+  it('', () => {
+    const math = new Plurimath('∑_𝑥^𝑦 𝑧', 'unicode')
+
+    expect(math.toMathml(true).trim()).toBe('<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">\n  <mstyle displaystyle="true">\n    <mrow intent=":sum(𝑥,𝑦,$naryand)">\n      <munderover>\n        <mo>&#x2211;</mo>\n        <mi>&#x1d465;</mi>\n        <mi>&#x1d466;</mi>\n      </munderover>\n      <mrow arg="naryand">\n        <mi>&#x1d467;</mi>\n      </mrow>\n    </mrow>\n  </mstyle>\n</math>')
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,8 @@ export default class Plurimath {
     return this.data.$to_latex();
   }
 
-  toMathml() {
-    return this.data.$to_mathml();
+  toMathml(intent: boolean = false) {
+    return this.data.$to_mathml(new Map([["intent", intent]]));
   }
 
   toHtml() {

--- a/src/plurimath-opal.d.ts
+++ b/src/plurimath-opal.d.ts
@@ -7,13 +7,12 @@ declare namespace Opal {
     namespace Math {
       type Format = 'asciimath' | 'latex' | 'mathml' | 'html' | 'unicode' | 'omml'
       function $parse(data: string | unknown, format: Format): ParserResult
-
       type TransmuterFunction = () => string
 
       class ParserResult {
         $to_latex: TransmuterFunction
         $to_asciimath: TransmuterFunction
-        $to_mathml: TransmuterFunction
+        $to_mathml: (options?: Map<string, boolean>) => string
         $to_html: TransmuterFunction
         $to_omml: TransmuterFunction
         $to_display: (string) => string


### PR DESCRIPTION
This PR enables the `intent` argument support already available in **Plurimath**.

related to => plurimath/plurimath.org#66