### PR TITLE
build: point oga/ruby-ll submodules at lutaml/opal-* forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/plurimath/htmlentities
 [submodule "vendor/oga"]
 	path = vendor/oga
-	url = https://github.com/plurimath/oga
+	url = https://github.com/lutaml/opal-oga
 [submodule "vendor/parslet"]
 	path = vendor/parslet
 	url = https://github.com/plurimath/parslet
@@ -15,7 +15,7 @@
 	url = https://github.com/plurimath/plurimath
 [submodule "vendor/ruby-ll"]
 	path = vendor/ruby-ll
-	url = https://github.com/plurimath/ruby-ll
+	url = https://github.com/lutaml/opal-ruby-ll
 [submodule "vendor/opal"]
 	path = vendor/opal
 	url = https://github.com/plurimath/opal


### PR DESCRIPTION
## What

Updates the submodule URLs for `vendor/oga` and `vendor/ruby-ll` to point at the new lutaml-owned locations.

## Why

`plurimath/oga` and `plurimath/ruby-ll` have been transferred to `lutaml/opal-oga` and `lutaml/opal-ruby-ll`, where they now live as **direct forks of `yorickpeterse/oga` and `yorickpeterse/ruby-ll`** (previously they were forks of plurimath's forks, two hops from upstream).

GitHub auto-redirects the old plurimath/* URLs to the new lutaml/* locations, so existing clones keep working. This PR removes the redirect hop and makes the lineage explicit in our own config.

## Changes

- `.gitmodules` URL for `vendor/oga`: `plurimath/oga` → `lutaml/opal-oga`
- `.gitmodules` URL for `vendor/ruby-ll`: `plurimath/ruby-ll` → `lutaml/opal-ruby-ll`

## What does NOT change

- Submodule pins (`70aad15` for oga, `7d18b5f` for ruby-ll) — both commits exist identically in the new lutaml/* locations because GitHub transfer preserves all git history.
- Path-source Gemfile and `env/` scripts — they address submodules by local path (`vendor/oga`, `vendor/ruby-ll`), which is unaffected by the URL change.
- No code or test changes.

## After merge

Run `git submodule sync --recursive` in existing clones to refresh the URL config.
